### PR TITLE
fix: improve text readability under cursor

### DIFF
--- a/ghostty.tera
+++ b/ghostty.tera
@@ -24,5 +24,6 @@ palette = 15=#{{ if(cond=flavor.dark, t=subtext0.hex, f=surface1.hex) }}
 background = {{ base.hex }}
 foreground = {{ text.hex }}
 cursor-color = {{ rosewater.hex }}
+cursor-text = {{ base.hex }}
 selection-background = {{ overlay2 | mix(color=base, amount=0.2) | get(key="hex") }}
 selection-foreground = {{ text.hex }}


### PR DESCRIPTION
This configures `cursor-text` which makes text under cursor more readable.


|Before | After|
|---|---|
|<img width="103" alt="before" src="https://github.com/user-attachments/assets/08a261b3-5553-478c-9f09-87a0daaa54aa" /> | <img width="103" alt="after" src="https://github.com/user-attachments/assets/15ec9073-d5f6-4f2c-b6c7-9b419ab53355" />
