### PR TITLE
fix: swap color7 with color15 for dark flavors

### DIFF
--- a/ghostty.tera
+++ b/ghostty.tera
@@ -12,7 +12,7 @@ palette = 3=#{{ yellow.hex }}
 palette = 4=#{{ blue.hex }}
 palette = 5=#{{ pink.hex }}
 palette = 6=#{{ teal.hex }}
-palette = 7=#{{ if(cond=flavor.dark, t=subtext1.hex, f=surface2.hex) }}
+palette = 7=#{{ if(cond=flavor.dark, t=subtext0.hex, f=surface2.hex) }}
 palette = 8=#{{ if(cond=flavor.dark, t=surface2.hex, f=subtext0.hex) }}
 palette = 9=#{{ red.hex }}
 palette = 10=#{{ green.hex }}
@@ -20,7 +20,7 @@ palette = 11=#{{ yellow.hex }}
 palette = 12=#{{ blue.hex }}
 palette = 13=#{{ pink.hex }}
 palette = 14=#{{ teal.hex }}
-palette = 15=#{{ if(cond=flavor.dark, t=subtext0.hex, f=surface1.hex) }}
+palette = 15=#{{ if(cond=flavor.dark, t=subtext1.hex, f=surface1.hex) }}
 background = {{ base.hex }}
 foreground = {{ text.hex }}
 cursor-color = {{ rosewater.hex }}

--- a/themes/catppuccin-frappe.conf
+++ b/themes/catppuccin-frappe.conf
@@ -5,7 +5,7 @@ palette = 3=#e5c890
 palette = 4=#8caaee
 palette = 5=#f4b8e4
 palette = 6=#81c8be
-palette = 7=#b5bfe2
+palette = 7=#a5adce
 palette = 8=#626880
 palette = 9=#e78284
 palette = 10=#a6d189
@@ -13,7 +13,7 @@ palette = 11=#e5c890
 palette = 12=#8caaee
 palette = 13=#f4b8e4
 palette = 14=#81c8be
-palette = 15=#a5adce
+palette = 15=#b5bfe2
 background = 303446
 foreground = c6d0f5
 cursor-color = f2d5cf

--- a/themes/catppuccin-macchiato.conf
+++ b/themes/catppuccin-macchiato.conf
@@ -5,7 +5,7 @@ palette = 3=#eed49f
 palette = 4=#8aadf4
 palette = 5=#f5bde6
 palette = 6=#8bd5ca
-palette = 7=#b8c0e0
+palette = 7=#a5adcb
 palette = 8=#5b6078
 palette = 9=#ed8796
 palette = 10=#a6da95
@@ -13,7 +13,7 @@ palette = 11=#eed49f
 palette = 12=#8aadf4
 palette = 13=#f5bde6
 palette = 14=#8bd5ca
-palette = 15=#a5adcb
+palette = 15=#b8c0e0
 background = 24273a
 foreground = cad3f5
 cursor-color = f4dbd6

--- a/themes/catppuccin-mocha.conf
+++ b/themes/catppuccin-mocha.conf
@@ -5,7 +5,7 @@ palette = 3=#f9e2af
 palette = 4=#89b4fa
 palette = 5=#f5c2e7
 palette = 6=#94e2d5
-palette = 7=#bac2de
+palette = 7=#a6adc8
 palette = 8=#585b70
 palette = 9=#f38ba8
 palette = 10=#a6e3a1
@@ -13,7 +13,7 @@ palette = 11=#f9e2af
 palette = 12=#89b4fa
 palette = 13=#f5c2e7
 palette = 14=#94e2d5
-palette = 15=#a6adc8
+palette = 15=#bac2de
 background = 1e1e2e
 foreground = cdd6f4
 cursor-color = f5e0dc


### PR DESCRIPTION
According to https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md#terminals, `color7` should be Subtext 0 and `color15` should be Subtext 1 for dark flavors (Subtext 1 is brighter than Subtext 0, and `color15` is the bright version of `color7`).