### PR TITLE
fix: crust cursor text color for dark flavors

### DIFF
--- a/ghostty.tera
+++ b/ghostty.tera
@@ -24,6 +24,6 @@ palette = 15=#{{ if(cond=flavor.dark, t=subtext1.hex, f=surface1.hex) }}
 background = {{ base.hex }}
 foreground = {{ text.hex }}
 cursor-color = {{ rosewater.hex }}
-cursor-text = {{ base.hex }}
+cursor-text = {{ if(cond=flavor.light, t=base.hex, f=crust.hex) }}
 selection-background = {{ overlay2 | mix(color=base, amount=0.2) | get(key="hex") }}
 selection-foreground = {{ text.hex }}

--- a/themes/catppuccin-frappe.conf
+++ b/themes/catppuccin-frappe.conf
@@ -17,6 +17,6 @@ palette = 15=#b5bfe2
 background = 303446
 foreground = c6d0f5
 cursor-color = f2d5cf
-cursor-text = 303446
+cursor-text = 232634
 selection-background = 44495d
 selection-foreground = c6d0f5

--- a/themes/catppuccin-macchiato.conf
+++ b/themes/catppuccin-macchiato.conf
@@ -17,6 +17,6 @@ palette = 15=#b8c0e0
 background = 24273a
 foreground = cad3f5
 cursor-color = f4dbd6
-cursor-text = 24273a
+cursor-text = 181926
 selection-background = 3a3e53
 selection-foreground = cad3f5

--- a/themes/catppuccin-mocha.conf
+++ b/themes/catppuccin-mocha.conf
@@ -17,6 +17,6 @@ palette = 15=#bac2de
 background = 1e1e2e
 foreground = cdd6f4
 cursor-color = f5e0dc
-cursor-text = 1e1e2e
+cursor-text = 11111b
 selection-background = 353749
 selection-foreground = cdd6f4


### PR DESCRIPTION
According to https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md#terminals Cursor text should be Base for Latte, and Crust for other flavors.

And according to https://whiskers.catppuccin.com/reference/context-variables/#flavor-light Latte is a light flavor, while other flavors are dark.

Thus the condition checks whether the flavor is light.